### PR TITLE
2/2: Allow loading of properties from vendor/overlay/local.prop

### DIFF
--- a/libc/include/sys/_system_properties.h
+++ b/libc/include/sys/_system_properties.h
@@ -82,6 +82,7 @@ struct prop_msg
 #define PROP_PATH_SYSTEM_BUILD     "/system/build.prop"
 #define PROP_PATH_SYSTEM_DEFAULT   "/system/default.prop"
 #define PROP_PATH_LOCAL_OVERRIDE   "/data/local.prop"
+#define PROP_PATH_VENDOR_DEFAULT   "/vendor/overlay/local.prop"
 #define PROP_PATH_FACTORY          "/factory/factory.prop"
 
 /*


### PR DESCRIPTION
Is to compliment Runtime Resource overlays if using custom properties

Change-Id: Id1b22d5597ba0d0a400039795bfa710ab7f5f00d

PS2: define needs to be lowercase

Change-Id: Ib3eb2a8eee60ce101d831a9e975928f01dd40bcd